### PR TITLE
Bumps openssl to match blueRSA 1.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 #if os(Linux)
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/IBM-Swift/OpenSSL.git", from: "0.0.0")
+    .package(url: "https://github.com/IBM-Swift/OpenSSL.git", from: "1.0.0")
 ]
 #else
 var dependencies: [Package.Dependency] = [


### PR DESCRIPTION
In order to migrate to the latest versions of blue RSA we need to bump our openssl dependency