### PR TITLE
Remove need for linker flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,13 @@ install:
 script:
   - swift package clean # clean built artifacts if present
   - swift package fetch # clones all dependencies
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift build; fi # build project
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift test; fi #run tests
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift build -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include; fi # build project
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift test -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include; fi #run tests
+  - swift build # build project
+  - swift test #run tests
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       gem install slather;
-      swift package generate-xcodeproj --xcconfig-overrides openssl.xcconfig;
+      swift package generate-xcodeproj;
       slather setup Swift-JWT-to-PEM.xcodeproj;
       xcodebuild -project SwiftJWKtoPEM.xcodeproj -scheme SwiftJWKtoPEM-Package  build;
       xcodebuild -project SwiftJWKtoPEM.xcodeproj -scheme SwiftJWKtoPEM-Package -enableCodeCoverage YES test;

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ var dependencies: [Package.Dependency] = [
 ]
 #else
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/IBM-Swift/OpenSSL-OSX.git", from: "0.4.0")
+    .package(url: "https://github.com/IBM-Swift/OpenSSL-OSX.git", from: "0.5.0")
 ]
 #endif
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,6 @@ Library to convert RSA keys in JWK/JWKS format to more popular formats such as P
 
 **Tested in Sierra only**
 
-## Build Instructions
-
-
-Since this library uses OpenSSL under the covers, it requires explicitly passing build and linker paths to the OpenSSL library. Additionally, `swift package generate-xcodeproj` doesn't add the proper flags when they are passed in using the flags, therefore they must be added to the generated xcode project.
-```
-swift build -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include
-```
-#### To generate Xcode project:
-```
-swift package generate-xcodeproj --xcconfig-overrides openssl.xcconfig
-```
-The extra xcconfig are needed to be able to build in Xcode or use `xcodebuild`.
-
-✨ Build magic ✨
-
-
 ## Usage
 
 ### TL;DR


### PR DESCRIPTION
With OpenSSL-OSX 0.5 you should no longer need to use linker flags for openssl. 
This PR updates the package.swift and  removes the flags from the README and travis build.